### PR TITLE
vsTAAmbk 使用报错，如何解决

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# vsTAAmbk 0.6.1
-A ported AA-script from Avisynth  
-For more detials NMM-HD：https://www.nmm-hd.org/newbbs/viewtopic.php?f=23&t=1666
+# vsTAAmbk 0.7.0
+An Anti-aliasing script ported from Avisynth  
+For more details NMM-HD：https://www.nmm-hd.org/newbbs/viewtopic.php?f=23&t=1666
 
 ##Requirements:
 
@@ -20,40 +20,115 @@ VapourSynth R28 or newer
 * Mvsfunc (and its requirements)
 
 ##Usage
+```python
 import vsTAAmbk as taa
 
-aa = taa.TAAmbkX(src, ...)
+aa = taa.TAAmbk(clip, aatype=1, aatypeu=None, aatypev=None, preaa=0, strength=0.0, cycle=0, mtype=None, mclip=None,
+           mthr=None, mthr2=None, mlthresh=None, mpand=(1, 0), txtmask=0, txtfade=0, thin=0, dark=0.0, sharp=0,
+           aarepair=0, postaa=None, src=None, stabilize=0, down8=True, showmask=0, eedi3m=True, **pn)
+```
 
 ##Paraments
 For more details please visit our threads in NMM-HD Forum.  
-* *aatype* - Select main AA method (Default 1).  
-    For more details about AA method please visit the thread in NMM-HD.
-* *strength* - The downscale factor of predown. 0~0.5 (Default 0).  
-    0 - No predown ; 0.5 - predown to half size
-* *preaa* - Select the preaa mode. -1~2 (Default 0).  
-    0 - No preaa ; 1 - Vertical ; 2 - Horizontal ; -1 - Both  
-    Pretty useful against residual comb.  
-* *cycle* - Cycle times of main AA (Default 0).  
-    The main purpose of cycle is to against 3D aliasing or clip with horrible aliasing
-* *mtype* - Select the method to build mask.  
-* *mclip* - Use your own mask clip instead of creating one.  
-* *mthr*,*mthr2* - Paraments for mask builder.  
-    For more details please see the thread in NMM-HD
-* *mlthresh* - Set luma thresh for n-pass mask. List  
-* *mpand* - Times of expanding and inpanding of the mask. (Default [2,1])  
-* *txtprt* - Create a mask to protect white captions on screen. 1~255 (Default None)  
-    Value is the luma thresh to determin whether it is captions
-* *thin* - Warp the line before main AA by aWarpSharp2. 0 - No thin (Default 0)  
-* *dark* - Darken the line before main AA by Toon. 0 - No darken (Default 0.0)  
-* *sharp* - Post-sharpen the clip after main AA. 0 - No sharpen (Default 0)  
-* *repair* - Repair the clip after Main AA. 0 - No repair (Default 0)  
-* *postaa* - Use soothe to counter the aliasing bring in by post-sharpen  
-* *src* - Use your own src clip for sharp, repair, mask merge, etc  
-* *stabilize* - Stabilize the temporal changes by MVTools. 0~3 (Default 0)  
-    Value is the temporal radius. 0 - No Stabilize
-* *down8* - Main AA will be done in 8bit if you set this True and input is 16bit  
-    Will use LimitFilter to limit the loss
-* *showmask* - show the mask  
-    0 - Normal output ; 1 - Mask only ; 2 - Stack mask and clip ; 3 - Interleave mask and clip ; -1 - Text mask only
-* *eedi3m* - Use nnedi3 to create a mask for eedi3's mclip. Effective when you have eedi3_092
-* *other paraments* - Will be collected into a dict for particular aatype
+* *clip*:<br />
+    clip to process.<br />
+	supported format: Gray and YUV with any subsampling whose bits depth is 8bit, 10bit or 16bit.<br />
+
+* *aatype*: (Default: 1)<br />
+    Select main AA kernel for Y plane.<br />
+	Value can be integer whose meaning is same with original TAA script.<br />
+	Value can also be name of particular AA kernel.<br />
+    For more details about AA kernel please visit the thread in NMM-HD.<br />
+
+* *aatypeu*: (Default: same as aatype)<br />
+    Select main AA kernel for U plane if clip is YUV.<br />
+
+* *aatypev*: (Default: same as aatype)<br />
+    Select main AA kernel for V plane if clip is YUV.<br />
+
+* *strength*: (Default: 0)<br />
+    The strength of predown. Valid range is 0~0.5<br />
+	Before applying main AA kernel, the clip is downscale to (1-strength)*clip_resolution first
+	and then upscale to original resolution by main AA kernel. This may help with dealing clip
+	with terrible aliasing which commonly caused by poor upscaling.<br />
+	Automatically disabled when using an AA kernel which is not suitable for upscaling.<br />
+
+* *preaa*: (Default: 0)<br />
+    Select the preaa mode. 0: No preaa; 1: Vertical; 2: Horizontal; -1: Both. <br />
+    Perform a preaa before applying main AA kernel.<br />
+	Preaa is basically an simplified version of daa.<br />
+	Pretty useful to against residual comb caused by poor deinterlace.<br />
+
+* *cycle*: (Default: 0)<br />
+    Set times of loop of main AA kernel.<br />
+    Use for very very terrible aliasing and 3D aliasing.<br />
+
+* *mtype*: (Default: 1)<br />
+    Select type of edge mask to use.<br />
+	Mask always be built under 8bit scale.<br />
+
+* *mclip*: (Default: None)<br />
+    Use your own mask clip instead of building one.<br />
+	If mclip is set, script won't build another one. And you should take care of
+	mask resolution, bitdepth, format, etc by yourself.<br />
+
+* *mthr*, *mthr2*:<br />
+    Paraments of mask.<br />
+    Meaning of them depends on particular mtype.<br />
+
+* *mlthresh*: (Default None)<br />
+    Set luma thresh for n-pass mask.<br />
+    Use a list or tuple to specify the sections of luma.<br />
+
+* *mpand*: (Default: (1, 0))<br />
+    Use a list or tuple to specify the loop of mask expanding and mask inpanding.<br />
+
+* *txtmask*: (Default: 0)<br />
+    Create a mask to protect white captions on screen.<br />
+    Value is the thresh of luma. Valid range is 0~255.<br />
+	When a area whose luma is greater than thresh and chroma is 128±2, it will be
+	considered as a caption.<br />
+
+* *txtfade*: (Default: 0)<br />
+    Set the length of fading. Useful for fading text.<br />
+
+* *thin*: (Default: 0)<br />
+    Warp the line by aWarpSharp2 before applying main AA kernel.<br />
+
+* *dark*: (Default: 0.0)<br />
+    Darken the line by Toon before applying main AA kernel.<br />
+
+* *sharp*: (Default: 0)<br />
+    Sharpen the clip after applying main AA kernel.<br />
+	0: No sharpen.<br />
+
+* *aarepair*: (Default: 0)<br />
+    Use repair to remove artifacts introduced by main AA kernel.<br />
+	According to different repair mode, the pixel in src clip will be replaced by
+	the median or average in 3x3 neighbour of processed clip.<br />
+	It's highly recommend to use repair when main AA kernel contain SangNom.<br />
+
+* *postaa*: (Default: False)<br />
+    Whether use soothe to counter the aliasing introduced by sharpening.<br />
+	
+* *src*: (Default: clip)<br />
+    Use your own src clip for sharp, repair, mask merge, etc.<br />
+
+* *stabilize*: (Default: 0)<br />
+    Stabilize the temporal changes by MVTools.<br />
+    Value is the temporal radius. Valid range is 0~3.<br />
+
+* *down8*: (Default: True)<br />
+    If you set this to True, the clip will be down to 8bit before applying main AA kernel
+	and up it back to original bitdepth after applying main AA kernel.<br />
+	LimitedFilter will be used to reduce the loss in depth conversion.<br />
+
+* *showmask*: (Default: 0)<br/>
+    Output the mask instead of processed clip if you set it to not 0.<br />
+    0: Normal output; 1: Mask only; 2: tack mask and clip; 3: Interleave mask and clip; -1: Text mask only<br />
+
+* *eedi3m*: (Default: True)<br />
+    Use nnedi3 to create a mask for eedi3's mclip. Effective when you have eedi3_092.<br />
+
+* *other paraments*:<br />
+    Will be collected into a dict for particular aatype.<br />

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 An Anti-aliasing script ported from Avisynth  
 For more details NMM-HD：https://www.nmm-hd.org/newbbs/viewtopic.php?f=23&t=1666
 
-##Requirements:
+## Requirements:
 
 VapourSynth R28 or newer
 
-####Plugins:
+#### Plugins:
 * EEDI2						
 * nnedi3						
 * RemoveGrain/Repair			
@@ -15,11 +15,11 @@ VapourSynth R28 or newer
 * sangnom
 * eedi3_092 (opt)
 
-####Script:
+#### Script:
 * HAvsFunc r22 or newer (and its requirements)
 * Mvsfunc (and its requirements)
 
-##Usage
+## Usage
 ```python
 import vsTAAmbk as taa
 
@@ -28,7 +28,7 @@ aa = taa.TAAmbk(clip, aatype=1, aatypeu=None, aatypev=None, preaa=0, strength=0.
            aarepair=0, postaa=None, src=None, stabilize=0, down8=True, showmask=0, eedi3m=True, **pn)
 ```
 
-##Paraments
+## Paraments
 For more details please visit our threads in NMM-HD Forum.  
 * *clip*:<br />
     clip to process.<br />

--- a/vsTAAmbk.py
+++ b/vsTAAmbk.py
@@ -602,7 +602,10 @@ def TAAmbk(clip, aatype=1, aatypeu=None, aatypev=None, preaa=0, strength=0.0, cy
     if src is None:
         src = clip
     else:
-        if clip.format.id is not src.format.id:
+        if clip.format.id != src.format.id:
+            print(clip.format.id)
+            print(src.format.id)
+            print(clip.format.id is not src.format.id)
             raise ValueError(MODULE_NAME + ': clip format and src format mismatch.')
         elif clip.width != src.width or clip.height != src.height:
             raise ValueError(MODULE_NAME + ': clip resolution and src resolution mismatch.')

--- a/vsTAAmbk.py
+++ b/vsTAAmbk.py
@@ -603,9 +603,6 @@ def TAAmbk(clip, aatype=1, aatypeu=None, aatypev=None, preaa=0, strength=0.0, cy
         src = clip
     else:
         if clip.format.id != src.format.id:
-            print(clip.format.id)
-            print(src.format.id)
-            print(clip.format.id is not src.format.id)
             raise ValueError(MODULE_NAME + ': clip format and src format mismatch.')
         elif clip.width != src.width or clip.height != src.height:
             raise ValueError(MODULE_NAME + ': clip resolution and src resolution mismatch.')

--- a/vsTAAmbk.py
+++ b/vsTAAmbk.py
@@ -1,784 +1,774 @@
-﻿##==========================================================
-## 2016.02.09			vsTAAmbk 0.6.1					
-##			Ported from TAAmbk 0.7.0 by Evalyn
-##			Maintained by Evalyn pov@mahou-shoujo.moe		
-##							kewenyu 1059902659@qq.com		
-##==========================================================
-##			Requirements:								
-##						EEDI2							
-##						nnedi3							
-##						RemoveGrain/Repair				
-##						fmtconv										
-##						MSmoosh							
-##						MVTools							
-##						TemporalSoften					
-##						sangnom							
-##						HAvsFunc(and its requirements)	
-##			VapourSynth R28 or newer
-##
-##==========================================================
-##==========================================================
-##														
-##	#### Only YUV colorfmaily is supported ! 	
-##	#### And input bitdepth must be 8 or 16 INT !			
-##		 												
-##==========================================================	 	
-
 import vapoursynth as vs
-import havsfunc as haf
 import mvsfunc as mvf
+import havsfunc as haf
+import functools
 
-def TAAmbkX(input, aatype=1, strength=0.0, preaa=0, cycle=0,
-            mtype=None, mclip=None, mthr=None, mthr2=None, mlthresh=None, mpand=[2, 1], txtprt=None,
-            thin=0, dark=0.0,
-            sharp=0, repair=0, postaa=None, src=None, stabilize=0,
-            down8=False, showmask=0, eedi3m=True, **pn):
-    
-    
-    core = vs.get_core()
-    
-    
-    # Constant Values
-    FUNCNAME = 'TAAmbkX'    # 'X' refer to 'Experimental'. Will change to vsTAAmbk when it is stable
-    W = input.width
-    H = input.height
-    BPS = input.format.bits_per_sample
-    COLOR_FAMILY = input.format.color_family
-    SAMPLE_TYPE = input.format.sample_type
-    ID = input.format.id
-    SUBSAMPLE = input.format.subsampling_h
-    IS_GRAY = True if input.format.num_planes == 1 else False
-    ABS_SHARP = abs(sharp)
-    STR = strength    # Strength of predown
-    PROCE_DEPTH = BPS if down8 is False else 8    # Process bitdepth
-    
-    
-    # Associated Default Values
-    if mtype is None:
-        mtype = 0 if preaa == 0 and aatype == 0 else 1
-    if postaa is None:
-        postaa = True if ABS_SHARP > 70 or (ABS_SHARP > 0.4 and ABS_SHARP < 1) else False
-    
-        
-    if src is None:
-        src = input
-    else:
-        if src.format.id != ID or src.width != W or src.height != H:
-            raise RuntimeError(FUNCNAME + ': format of src and input mismatch !')
-    
-    
-    # Input Check
-    if not isinstance(input, vs.VideoNode):
-        raise ValueError(FUNCNAME + ': input must be a clip !')
-    if COLOR_FAMILY == vs.YUV or COLOR_FAMILY == vs.GRAY:
-        if SAMPLE_TYPE != vs.INTEGER:
-            raise TypeError(FUNCNAME + ': input must be integer format !')
-        if not (BPS == 8 or BPS == 16):
-            raise TypeError(FUNCNAME + ': input must be 8bit or 16bit !')
-    else:
-        raise TypeError(FUNCNAME + ': input must be YUV or GRAY !')        
-        
-    
-############### Internal Functions ###################
-    def Preaa(input, mode):
-        nn = None if mode == 2 else core.nnedi3.nnedi3(input, field=3)
-        nnt = None if mode == 1 else core.nnedi3.nnedi3(core.std.Transpose(input), field=3).std.Transpose()
-        clph = None if mode == 2 else core.std.Merge(core.std.SelectEvery(nn, cycle=2, offsets=0), 
-                                                     core.std.SelectEvery(nn, cycle=2, offsets=1))
-        clpv = None if mode == 1 else core.std.Merge(core.std.SelectEvery(nnt, cycle=2, offsets=0), 
-                                                     core.std.SelectEvery(nnt, cycle=2, offsets=1))
-        clp = core.std.Merge(clph, clpv) if mode == -1 else None
-        if mode == 1:
-            return clph
-        elif mode == 2:
-            return clpv
+MODULE_NAME = 'vsTAAmbk'
+
+
+class Clip:
+    def __init__(self, clip):
+        self.core = vs.get_core()
+        self.clip = clip
+        if not isinstance(clip, vs.VideoNode):
+            raise TypeError(MODULE_NAME + ': clip is invalid.')
+        self.clip_width = clip.width
+        self.clip_height = clip.height
+        self.clip_bits = clip.format.bits_per_sample
+        self.clip_color_family = clip.format.color_family
+        self.clip_sample_type = clip.format.sample_type
+        self.clip_id = clip.format.id
+        self.clip_subsample_w = clip.format.subsampling_w
+        self.clip_subsample_h = clip.format.subsampling_h
+        self.clip_is_gray = True if clip.format.num_planes == 1 else False
+        # Register format for GRAY10
+        vs.GRAY10 = self.core.register_format(vs.GRAY, vs.INTEGER, 10, 0, 0).id
+
+
+class AAParent(Clip):
+    def __init__(self, clip, strength=0, down8=False):
+        super(AAParent, self).__init__(clip)
+        self.dfactor = 1 - min(strength, 0.5)
+        self.dw = round(self.clip_width * self.dfactor / 4) * 4
+        self.dh = round(self.clip_height * self.dfactor / 4) * 4
+        self.upw4 = round(self.dw * 0.375) * 4
+        self.uph4 = round(self.dh * 0.375) * 4
+        self.down8 = down8
+        self.process_depth = self.clip_bits
+        if down8 is True:
+            self.down_8()
+        if self.dfactor != 1:
+            self.clip = self.resize(self.clip, self.dw, self.dh, shift=0)
+        if self.clip_color_family is vs.GRAY:
+            if self.clip_sample_type is not vs.INTEGER:
+                raise TypeError(MODULE_NAME + ': clip must be integer format.')
         else:
-            return clp
-    
-    
-    def Lineplay(input, thin, dark):
-        if thin != 0 and dark != 0:
-            return haf.Toon(core.warp.AWarpSharp2(input, depth=int(thin)), str=float(dark))
-        elif thin == 0:
-            return haf.Toon(input, str=float(dark))
-        else:
-            return core.warp.AWarpSharp2(input, depth=int(thin))
-    
-    
-    def Stabilize(clip, src, delta):
-        aaDiff = core.std.MakeDiff(src, input, planes=[0, 1, 2])
-        inSuper = core.mv.Super(clip, pel=1)
-        diffSuper = core.mv.Super(aaDiff, pel=1, levels=1)
-        
-        fv3 = core.mv.Analyse(inSuper, isb=False, delta=3, overlap=8, blksize=16) if delta == 3 else None
-        fv2 = core.mv.Analyse(inSuper, isb=False, delta=2, overlap=8, blksize=16) if delta >= 2 else None
-        fv1 = core.mv.Analyse(inSuper, isb=False, delta=1, overlap=8, blksize=16) if delta >= 1 else None
-        bv1 = core.mv.Analyse(inSuper, isb=True, delta=1, overlap=8, blksize=16) if delta >= 1 else None
-        bv2 = core.mv.Analyse(inSuper, isb=True, delta=2, overlap=8, blksize=16) if delta >= 2 else None
-        bv3 = core.mv.Analyse(inSuper, isb=True, delta=3, overlap=8, blksize=16) if delta == 3 else None
-        
-        if stabilize == 1:
-            diffStab = core.mv.Degrain1(aaDiff, diffSuper, bv1, fv1)
-        elif stabilize == 2:
-            diffStab = core.mv.Degrain2(aaDiff, diffSuper, bv1, fv1, bv2, fv2)
-        elif stabilize == 3:
-            diffStab = core.mv.Degrain3(aaDiff, diffSuper, bv1, fv1, bv2, fv2, bv3, fv3)
-        else:
-            raise ValueError(FUNCNAME + ': \"stabilize\" int(0~3) invaild !')
-        
-        # Caculate for high-bitdepth support
-        neutral = 128 << (BPS - 8)
-        
-        compareExpr = "x {neutral} - abs y {neutral} - abs < x y ?".format(neutral=neutral)
-        diffCompare = core.std.Expr([aaDiff, diffStab], compareExpr)
-        diffCompare = core.std.Merge(diffCompare, diffStab, 0.6)
-        
-        aaStab = core.std.MakeDiff(src, diffCompare, planes=[0, 1, 2])
-        return aaStab
-    
-    
-    def Soothe(sharped, src):
-        neutral = 128 << (BPS - 8)
-        peak = (1 << BPS) - 1
-        multiple = peak / 255
-        const = 100 * multiple
-        keep = 24
-        kp = keep * multiple
-        
-        diff1Expr = "x y - {neutral} +".format(neutral=neutral)
-        diff1 = core.std.Expr([src, sharped], diff1Expr)
-        
-        diff2 = core.focus.TemporalSoften(diff1, radius=1, luma_threshold=255, chroma_threshold=255, scenechange=32, mode=2)
-        
-        diff3Expr = "x {neutral} - y {neutral} - * 0 < x {neutral} - {const} / {kp} * {neutral} + x {neutral} - abs y {neutral} - abs > x {kp} * y {const} {kp} - * + {const} / x ? ?".format(neutral=neutral, const=const, kp=kp)
-        diff3 = core.std.Expr([diff1, diff2], diff3Expr)
-        
-        finalExpr = "x y {neutral} - -".format(neutral=neutral)
-        final = core.std.Expr([src, diff3], finalExpr)
-        
-        return final
-    
-    
-    def Sharp(aaclip, aasrc):
-        if sharp >= 1:
-            sharped = haf.LSFmod(aaclip, strength=int(ABS_SHARP), defaults="old", source=aasrc)
-        elif sharp > 0:
-            per = int(40*ABS_SHARP)
-            matrix = [-1, -2, -1, -2, 52 - per, -2, -1, -2, -1]
-            sharped = core.std.Convolution(aaclip, matrix)
-        elif sharp > -1:
-            sharped = haf.LSFmod(aaclip, strength=round(ABS_SHARP*100), defaults="fast", source=aasrc)
-        elif sharp == -1:
-            clipb = core.std.MakeDiff(aaclip, core.rgvs.RemoveGrain(aaclip, mode=20 if W > 1100 else 11))
-            clipb = core.rgvs.Repair(clipb, core.std.MakeDiff(aasrc, aaclip), mode=13)
-            sharped = core.std.MergeDiff(aaclip, clipb)
-        else:
-            sharped = haf.LSFmod(aaclip, strength=int(ABS_SHARP), defaults="slow", source=aasrc)
-            
-        return sharped
-        
-        
-        
-        
-######################### Begin of Main AAtype#########################    
-    class aaParent:
-        def __init__(self):
-            self.dfactor = 1 - min(STR, 0.5)
-            self.dw = round(W * self.dfactor / 4) * 4
-            self.dh = round(H * self.dfactor / 4) * 4
-            self.upw4 = round(self.dw * 0.375) * 4
-            self.uph4 = round(self.dh * 0.375) * 4
-    
-        @staticmethod
-        def aaResizer(clip, w, h, shift):
-            try:
-                y = core.std.ShufflePlanes(clip, 0, vs.GRAY)
-                u = core.std.ShufflePlanes(clip, 1, vs.GRAY)
-                v = core.std.ShufflePlanes(clip, 2, vs.GRAY)
-                y_resized = core.resize.Spline36(y, w, h, src_top=shift)
-                u_resized = core.resize.Spline36(u, int(w / (1 << SUBSAMPLE)), int(h / (1 << SUBSAMPLE)), src_top=shift)
-                v_resized = core.resize.Spline36(v, int(w / (1 << SUBSAMPLE)), int(h / (1 << SUBSAMPLE)), src_top=shift)
-                resized = core.std.ShufflePlanes([y_resized, u_resized, v_resized], [0, 0, 0], vs.YUV)
-                if resized.format.bits_per_sample != PROCE_DEPTH:
-                    resized = mvf.Depth(resized, PROCE_DEPTH)
-                return resized
-            except vs.Error:
-                resized = core.fmtc.resample(clip, w, h, sy=[shift, shift * (1 << SUBSAMPLE)])
-                return resized
-    
-    class aaNnedi3(aaParent):
-        def __init__(self, args):
-            super(aaNnedi3, self).__init__()
-            self.nsize = args.get('nsize', 3)
-            self.nns = args.get('nns', 1)
-            self.qual = args.get('qual', 2)
-    
-        def AA(self, clip):
-            aaed = core.nnedi3.nnedi3(clip, field=1, dh=True, nsize=self.nsize, nns=self.nns, qual=self.qual)
-            aaed = self.aaResizer(aaed, W, H, -0.5)
-            aaed = core.std.Transpose(aaed)
-            aaed = core.nnedi3.nnedi3(aaed, field=1, dh=True, nsize=self.nsize, nns=self.nns, qual=self.qual)
-            aaed = self.aaResizer(aaed, H, W, -0.5)
-            aaed = core.std.Transpose(aaed)
-            return aaed
-        
+            raise TypeError(MODULE_NAME + ': clip must be GRAY family.')
 
-    class aaNnedi3SangNom(aaNnedi3):
-        def __init__(self, args):
-            super(aaNnedi3SangNom, self).__init__(args)
-            self.aa = args.get('aa', 48)
-        
-        def AA(self, clip):
-            aaed = core.nnedi3.nnedi3(clip, field=1, dh=True, nsize=self.nsize, nns=self.nns, qual=self.qual)
-            aaed = self.aaResizer(aaed, W, self.uph4, -0.5)
-            aaed = core.std.Transpose(aaed)
-            aaed = core.nnedi3.nnedi3(aaed, field=1, dh=True, nsize=self.nsize, nns=self.nns, qual=self.qual)
-            aaed = self.aaResizer(aaed, self.uph4, self.upw4, -0.5)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = core.std.Transpose(aaed)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = self.aaResizer(aaed, W, H, 0)
-            return aaed
-    
-    
-    class aaNnedi3UpscaleSangNom(aaNnedi3SangNom):
-        def __init__(self, args):
-            super(aaNnedi3UpscaleSangNom, self).__init__(args)
-            self.nsize = args.get('nsize', 1)
-            self.nns = args.get('nns', 3)
-            self.qual = args.get('qual', 2)
-
-
-    class aaEedi3(aaParent):
-        def __init__(self, eedi3m, args):
-            super(aaEedi3, self).__init__()
-            self.alpha = args.get('alpha', 0.5)
-            self.beta = args.get('beta', 0.2)
-            self.gamma = args.get('gamma', 20)
-            self.nrad = args.get('nrad', 3)
-            self.mdis = args.get('mdis', 30)
-            self.eedi3m = eedi3m
-            try:
-                self.eedi3 = core.eedi3_092.eedi3    # Check whether eedi3_092 is available
-            except AttributeError:
-                self.eedi3 = core.eedi3.eedi3
-                self.eedi3m = False    # Disable eedi3m if eedi3_092 is not available
-
-        @staticmethod
-        def down8(clip):
-            if BPS == 16 and PROCE_DEPTH != 8:
-                return mvf.Depth(clip, 8)
-            else:
-                return clip
-        
-        def build_eedi3_mask(self, clip):
-            clip = self.down8(clip)
-            eedi3_mask = core.nnedi3.nnedi3(clip, field=1, show_mask=True)
-            eedi3_mask = core.std.Expr([eedi3_mask, clip], "x 254 > x y - 0 = not and 255 0 ?")
-            eedi3_mask_turn = core.std.Transpose(eedi3_mask)
-            return [eedi3_mask, eedi3_mask_turn]
-        
-        def AA(self, clip):
-            if self.eedi3m is False:
-                aaed = self.eedi3(self.down8(clip), field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma, nrad=self.nrad, mdis=self.mdis)
-                aaed = self.aaResizer(aaed, W, H, -0.5)
-                aaed = core.std.Transpose(aaed)
-                aaed = self.eedi3(self.down8(aaed), field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma, nrad=self.nrad, mdis=self.mdis)
-                aaed = self.aaResizer(aaed, H, W, -0.5)
-                aaed = core.std.Transpose(aaed)
-                return mvf.Depth(aaed, PROCE_DEPTH)
-            else:
-                mask = self.build_eedi3_mask(clip)
-                aaed = self.eedi3(self.down8(clip), field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma, nrad=self.nrad, mdis=self.mdis, mclip=mask[0])
-                aaed = self.aaResizer(aaed, W, H, -0.5)
-                aaed = core.std.Transpose(aaed)
-                aaed = self.eedi3(self.down8(aaed), field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma, nrad=self.nrad, mdis=self.mdis, mclip=mask[1])
-                aaed = self.aaResizer(aaed, H, W, -0.5)
-                aaed = core.std.Transpose(aaed)
-                return mvf.Depth(aaed, PROCE_DEPTH)
-
-    class aaEedi3SangNom(aaEedi3):
-        def __init__(self, eedi3m, args):
-            super(aaEedi3SangNom, self).__init__(eedi3m, args)
-            self.aa = args.get('aa', 48)
-
-        def build_eedi3_mask(self, clip):
-            clip = self.down8(clip)
-            eedi3_mask = core.nnedi3.nnedi3(clip, field=1, show_mask=True)
-            eedi3_mask = core.std.Expr([eedi3_mask, clip], "x 254 > x y - 0 = not and 255 0 ?")
-            eedi3_mask_turn = core.std.Transpose(eedi3_mask)
-            eedi3_mask_turn = core.resize.Bicubic(eedi3_mask_turn, self.uph4, W)
-            return [eedi3_mask, eedi3_mask_turn]
-        
-        def AA(self, clip):
-            if self.eedi3m is False:
-                aaed = core.eedi3.eedi3(self.down8(clip), field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma, nrad=self.nrad, mdis=self.mdis)
-                aaed = self.aaResizer(aaed, W, self.uph4, -0.5)
-                aaed = core.std.Transpose(aaed)
-                aaed = core.eedi3.eedi3(self.down8(aaed), field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma, nrad=self.nrad, mdis=self.mdis)
-                aaed = self.aaResizer(aaed, self.uph4, self.upw4, -0.5)
-                aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-                aaed = core.std.Transpose(aaed)
-                aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-                aaed = self.aaResizer(aaed, W, H, 0)
-                return mvf.Depth(aaed, PROCE_DEPTH)
-            else:
-                mask = self.build_eedi3_mask(clip)
-                aaed = self.eedi3(self.down8(clip), field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma, nrad=self.nrad, mdis=self.mdis, mclip=mask[0])
-                aaed = self.aaResizer(aaed, W, self.uph4, -0.5)
-                aaed = core.std.Transpose(aaed)
-                aaed = self.eedi3(self.down8(aaed), field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma, nrad=self.nrad, mdis=self.mdis, mclip=mask[1])
-                aaed = self.aaResizer(aaed, self.uph4, self.upw4, -0.5)
-                aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-                aaed = core.std.Transpose(aaed)
-                aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-                aaed = self.aaResizer(aaed, W, H, 0)
-                return mvf.Depth(aaed, PROCE_DEPTH)
-
-
-    class aaEedi2(aaParent):
-        def __init__(self, args):
-            super(aaEedi2, self).__init__()
-            self.mthresh = args.get('mthresh', 10)
-            self.lthresh = args.get('lthresh', 20)
-            self.vthresh = args.get('vthresh', 20)
-            self.maxd = args.get('maxd', 24)
-            self.nt = args.get('nt', 50)
-        def AA(self, clip):
-            aaed = core.eedi2.EEDI2(clip, 1, self.mthresh, self.lthresh, self.vthresh, maxd=self.maxd, nt=self.nt)
-            aaed = self.aaResizer(aaed, W, H, -0.5)
-            aaed = core.std.Transpose(aaed)
-            aaed = core.eedi2.EEDI2(aaed, 1, self.mthresh, self.lthresh, self.vthresh, maxd=self.maxd, nt=self.nt)
-            aaed = self.aaResizer(aaed, H, W, -0.5)
-            aaed = core.std.Transpose(aaed)
-            return aaed
-
-
-    class aaEedi2SangNom(aaEedi2):
-        def __init__(self, args):
-            super(aaEedi2SangNom, self).__init__(args)
-            self.aa = args.get('aa', 48)
-        
-        def AA(self, clip):
-            aaed = core.eedi2.EEDI2(clip, 1, self.mthresh, self.lthresh, self.vthresh, maxd=self.maxd, nt=self.nt)
-            aaed = self.aaResizer(aaed, W, self.uph4, -0.5)
-            aaed = core.std.Transpose(aaed)
-            aaed = core.eedi2.EEDI2(aaed, 1, self.mthresh, self.lthresh, self.vthresh, maxd=self.maxd, nt=self.nt)
-            aaed = self.aaResizer(aaed, self.uph4, self.upw4, -0.5)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = core.std.Transpose(aaed)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = self.aaResizer(aaed, W, H, 0)
-            return aaed
-
-
-    class aaSpline64NrSangNom(aaParent):
-        def __init__(self, args):
-            super(aaSpline64NrSangNom, self).__init__()
-            self.aa = args.get('aa', 48)
-    
-        def AA(self, clip):
-            aaed = core.fmtc.resample(clip, self.upw4, self.uph4, kernel="spline64")
-            aaed = mvf.Depth(aaed, PROCE_DEPTH)
-            aaGaussian = core.fmtc.resample(clip, self.upw4, self.uph4, kernel="gaussian", a1=100)
-            aaGaussian = mvf.Depth(aaGaussian, PROCE_DEPTH)
-            aaed = core.rgvs.Repair(aaed, aaGaussian, 1)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = core.std.Transpose(aaed)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = core.std.Transpose(self.aaResizer(aaed, H, W, 0))
-            return aaed
-
-
-    class aaSpline64SangNom(aaParent):
-        def __init__(self, args):
-            super(aaSpline64SangNom, self).__init__()
-            self.aa = args.get('aa', 48)
-        
-        def AA(self, clip):
-            aaed = core.fmtc.resample(clip, W, self.uph4, kernel="spline64")
-            aaed = mvf.Depth(aaed, PROCE_DEPTH)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = core.std.Transpose(self.aaResizer(aaed, W, H, 0))
-            aaed = core.fmtc.resample(aaed, H, self.upw4, kernel="spline64")
-            aaed = mvf.Depth(aaed, PROCE_DEPTH)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = core.std.Transpose(self.aaResizer(aaed, H, W, 0))
-            return aaed
-
-
-    class aaPointSangNom(aaParent):
-        def __init__(self, args):
-            super(aaPointSangNom, self).__init__()
-            self.aa = args.get('aa', 48)
-            self.upw = self.dw * 2
-            self.uph = self.dh * 2
-    
-        def AA(self, clip):
-            aaed = core.resize.Point(clip, self.upw, self.uph)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = core.std.Transpose(aaed)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = self.aaResizer(core.std.Transpose(aaed), W, H, 0)
-            return aaed
-            
-            
-    # An AA method from VCB-S
-    class aaEedi2PointSangNom(aaEedi2SangNom):
-        def __init__(self, args):
-            super(aaEedi2PointSangNom, self).__init__(args)
-        
-        def AA(self, clip):
-            aaed = core.eedi2.EEDI2(clip, 1, self.mthresh, self.lthresh, self.vthresh, maxd=self.maxd, nt=self.nt)
-            aaed = self.aaResizer(aaed, W, H*2, -0.5)
-            aaed = core.std.Transpose(aaed)
-            aaed = core.resize.Point(aaed, H*2, W*2)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = core.std.Transpose(aaed)
-            aaed = core.sangnom.SangNom(aaed, aa=self.aa)
-            aaed = core.std.Transpose(aaed)
-            aaed = self.aaResizer(aaed, H, W, -0.5)
-            aaed = core.std.Transpose(aaed)
-            return aaed
-            
-            
-
-##################### End of Main AAType ########################
-
-
-##################### Begin of Mtype ###########################
-
-    class mParent:
-        def __init__(self):
-            self.outdepth = vs.GRAY8 if PROCE_DEPTH == 8 else vs.GRAY16
-            self.multi = 1 if PROCE_DEPTH == 8 else 257    # Multiple factor of Expr
-
-        @staticmethod
-        def mParaInit(mthr, default):
-            if mthr is not None:
-                return mthr
-            else:
-                return default
-
-        @staticmethod
-        def mCheckList(list1, list2, list3):
-            if len(list1) != (len(list2) - 1):
-                raise ValueError(FUNCNAME + ': num of mthr and mlthresh mismatch !')
-            if len(list2) != len(list3):
-                raise ValueError(FUNCNAME + ': num of mthr and mthr2 mismatch !')
-        
-        @staticmethod    
-        def mGetGray(clip):
-            return core.std.ShufflePlanes(clip, 0, vs.GRAY)
-    
-        '''
-        def mBlankClip(clip):
-            blc = core.std.BlankClip(clip, format=vs.GRAY8 if PROCE_DEPTH == 8 else vs.GRAY16)
-            return blc 
-        '''  
-    
-        @staticmethod
-        def mExpand(clip, time):
-            for i in range(time):
-                clip = core.std.Maximum(clip, 0)
-            return clip
-    
-        @staticmethod
-        def mInpand(clip, time):
-            for i in range(time):
-                clip = core.std.Minimum(clip, 0)
-            return clip
-        
-    class mCanny(mParent):
-        def __init__(self, mthr, mthr2, mlthresh, mpand):
-            super(mCanny, self).__init__()
-            self.sigma = self.mParaInit(mthr, 1.2)
-            self.t_h = self.mParaInit(mthr2, 8.0)
-            self.mlthresh = mlthresh
-            self.mpand = mpand
-    
-        def getMask(self, clip):
-            clip = self.mGetGray(clip)
-            if isinstance(self.sigma, list):
-                self.mCheckList(self.mlthresh, self.sigma, self.t_h)
-                mask = core.tcanny.TCanny(clip, sigma=self.sigma[0], t_h=self.t_h[0], mode=0, planes=0)
-                
-                for i in range(len(self.mlthresh)):
-                    tmask = core.tcanny.TCanny(clip, sigma=self.sigma[i+1], t_h=self.t_h[i+1], mode=0, planes=0)
-                    expr = "x " + str(self.mlthresh[i]) + " < z y ?"
-                    mask = core.std.Expr([clip, tmask, mask], expr)
-                mask = core.std.Expr(mask, "x " + str(self.multi) + " *", self.outdepth)            
-            
-            else:
-                mask = core.tcanny.TCanny(clip, sigma=self.sigma, t_h=self.t_h, mode=0, planes=0)
-        
-            if self.mpand is not 0:
-                mask = self.mExpand(mask, self.mpand[0])
-                mask = self.mInpand(mask, self.mpand[1])
-            
-            return core.rgvs.RemoveGrain(mask, 20)
-
-    class mCannySobel(mParent):
-        def __init__(self, mthr, mthr2, mlthresh, mpand):
-            super(mCannySobel, self).__init__()
-            self.binarize = self.mParaInit(mthr, 48)
-            self.sigma = self.mParaInit(mthr2, 1.2)
-            self.mlthresh = mlthresh
-            self.mpand = mpand
-        
-        @staticmethod
-        def mCheckList(list1, list2):
-            if len(list1) != (len(list2) - 1):
-                raise ValueError(FUNCNAME + ': num of mthr and mlthresh mismatch !')
-    
-        def getMask(self, clip):
-            clip = self.mGetGray(clip)
-            eemask = core.tcanny.TCanny(clip, sigma=self.sigma, mode=1, op=2, planes=0)
-            if isinstance(self.binarize, list):
-                self.mCheckList(self.mlthresh, self.binarize)
-                expr = "x " + str(self.binarize[0]) + " < 0 255 ?"
-                mask = core.std.Expr(eemask, expr, self.outdepth)
-            
-                for i in range(len(self.mlthresh)):
-                    texpr = "x " + str(self.binarize[i+1]) + " < 0 255 ?"
-                    tmask = core.std.Expr(eemask, texpr)
-                    expr = "x " + str(self.mlthresh[i]) + " < z y ?"
-                    mask = core.std.Expr([clip, tmask, mask], expr) 
-                mask = core.std.Expr(mask, "x " + str(self.multi) + " *", self.outdepth)
-            
-            else:
-                expr = "x " + str(self.binarize) + " < 0 255 " + str(self.multi) + " * ?"
-                mask = core.std.Expr(eemask, expr, self.outdepth)
-            
-            if self.mpand is not 0:
-                mask = self.mExpand(mask, self.mpand[0])
-                mask = self.mInpand(mask, self.mpand[1])
-
-            return core.rgvs.RemoveGrain(mask, 20)
-
-    class mPrewitt(mParent):
-        def __init__(self, mthr, mlthresh, mpand):
-            super(mPrewitt, self).__init__()
-            self.mfactor = self.mParaInit(mthr, 62)
-            self.mlthresh = mlthresh
-            self.mpand = mpand
-
-        @staticmethod
-        def mCheckList(list1, list2):
-            if len(list1) != (len(list2) - 1):
-                raise ValueError(FUNCNAME + ': num of mthr and mlthresh mismatch !')
-
-        @staticmethod
-        def mInflate(clip, time):
-            for i in range(time):
-                clip = core.std.Inflate(clip)
-            return clip
-
-        @staticmethod
-        def mDeflate(clip, time):
-            for i in range(time):
-                clip = core.std.Deflate(clip)
-            return clip
-
-        def getMask(self, clip):
-            clip = self.mGetGray(clip)
-            emask_1 = core.std.Convolution(clip, [1, 1, 0, 1, 0, -1, 0, -1, -1], divisor=1, saturate=False)
-            emask_2 = core.std.Convolution(clip, [1, 1, 1, 0, 0, 0, -1, -1, -1], divisor=1, saturate=False)
-            emask_3 = core.std.Convolution(clip, [1, 0, -1, 1, 0, -1, 1, 0, -1], divisor=1, saturate=False)
-            emask_4 = core.std.Convolution(clip, [0, -1, -1, 1, 0, -1, 1, 1, 0], divisor=1, saturate=False)
-            expr = "x y max z max a max"
-            emask = core.std.Expr([emask_1, emask_2, emask_3, emask_4], expr)
-
-            if isinstance(self.mfactor, list):
-                self.mCheckList(self.mlthresh, self.mfactor)
-                expr = "x " + str(self.mfactor[0]) + " <= x 2 / x 1.4 pow ?"
-                mask = core.std.Expr(emask, expr, self.outdepth)
-                for i in range(len(self.mlthresh)):
-                    texpr = "x " + str(self.mfactor[i+1]) + " <= x 2 / x 1.4 pow ?"
-                    tmask = core.std.Expr(emask, texpr)
-                    expr = "x " + str(self.mlthresh[i]) + " < z y ?"
-                    mask = core.std.Expr([clip, tmask, mask], expr)
-                mask = core.std.Expr(mask, "x " + str(self.multi) + " *", self.outdepth)
-            else:
-                expr = "x {factor} <= x 2 / {multi} * x 1.4 pow {multi} * ?".format(factor=self.mfactor, multi=self.multi)
-                mask = core.std.Expr(emask, expr)
-            if self.mpand is not 0:
-                mask = self.mInflate(mask, self.mpand[0])
-                mask = self.mDeflate(mask, self.mpand[1])
-            return core.rgvs.RemoveGrain(mask, 20)
-
-    
-    class mText(mParent):
-        def __init__(self, luma):
-            super(mText, self).__init__()
-            self.luma = luma
-            self.uvdiff = 1
-            #self.neutral = 128
-            #self.max = 255
-        
-        def getMask(self, clip):
-            y = core.std.ShufflePlanes(clip, 0, vs.GRAY)
-            u = mvf.Depth(core.fmtc.resample(core.std.ShufflePlanes(clip, 1, vs.GRAY), W, H, sx=0.25), 8)
-            v = mvf.Depth(core.fmtc.resample(core.std.ShufflePlanes(clip, 2, vs.GRAY), W, H, sx=0.25), 8)
-            txtExpr = "x {luma} > y 128 - abs {uvdiff} <= and z 128 - abs {uvdiff} <= and 255 0 ?".format(luma=self.luma, uvdiff=self.uvdiff)
-            txtmask = core.std.Expr([y, u, v], txtExpr, self.outdepth)
-            if BPS == 16:
-                txtmask = core.std.Expr(txtmask, "x 257 *", vs.GRAY16)
-            txtmask = core.std.Maximum(txtmask).std.Maximum().std.Maximum()
-            return txtmask
-            
-################### End of Mtype ######################
-
-
-################### Begin of Main Workflow ################
-
-    input8 = input if BPS == 8 else mvf.Depth(input, 8)
-    if BPS == 16 and down8 is True:
-        input = input8
-    
-    # Pre-Antialiasing
-    preaaClip = input if preaa == 0 else Preaa(input, preaa)
-    
-    # Pre-Lineplay (Considered useless)
-    lineplayClip = preaaClip if (thin == 0 and dark == 0) else Lineplay(preaaClip, thin, dark)
-    
-    # Instantiate Main Anti-Aliasing Object, pn is a dict
-    if aatype == 1 or aatype == "Eedi2":
-        aaObj = aaEedi2(pn)
-        
-    elif aatype == 2 or aatype == "Eedi3":
-        aaObj = aaEedi3(eedi3m, pn)
-        
-    elif aatype == 3 or aatype == "Nnedi3":
-        aaObj = aaNnedi3(pn)
-        
-    elif aatype == 4 or aatype == "Nnedi3UpscaleSangNom":
-        aaObj = aaNnedi3UpscaleSangNom(pn)
-        
-    elif aatype == 5 or aatype == "Spline64NrSangNom":
-        aaObj = aaSpline64NrSangNom(pn)
-        
-    elif aatype == 6 or aatype == "Spline64SangNom":
-        aaObj = aaSpline64SangNom(pn)
-        
-    elif aatype == "PointSangNom":
-        aaObj = aaPointSangNom(pn)
-        
-    elif aatype == -1 or aatype == "Eedi2SangNom":
-        aaObj = aaEedi2SangNom(pn)
-        
-    elif aatype == -2 or aatype == "Eedi3SangNom":
-        aaObj = aaEedi3SangNom(eedi3m, pn)
-        
-    elif aatype == -3 or aatype == "Nnedi3SangNom":
-        aaObj = aaNnedi3SangNom(pn)
-        
-    elif aatype == 'Eedi2PointSangNom':
-        aaObj = aaEedi2PointSangNom(pn)
-        
-    elif aatype == 0:
-        pass
-
-    else:
-        raise ValueError(FUNCNAME + ': Unknown AAtype !')
-        
-    # Get Anti-Aliasing Clip
-    if aatype != 0:
-        if strength != 0:
-            lineplayClip = aaObj.aaResizer(lineplayClip, aaObj.dw, aaObj.dh, 0)
-        aaedClip = aaObj.AA(lineplayClip)
-        # Cycle it as you will
-        while cycle > 0:
-            aaedClip = aaObj.AA(aaedClip)
-            cycle = cycle - 1
-            
-    else:
-        aaedClip = lineplayClip
-        
-    # Back 16 if BPS is 16 and down8
-    if BPS == 16 and down8 is True:
-        aaedClip = mvf.Depth(aaedClip, 16)
-        
-    # Sharp it
-    sharpedClip = aaedClip if sharp == 0 else Sharp(aaedClip, src)
-    
-    # PostAA
-    if postaa is True:
-        sharpedClip = Soothe(sharpedClip, aaedClip)
-    
-    # Repair it
-    repairedClip = sharpedClip if repair == 0 else core.rgvs.Repair(src, sharpedClip, repair)
-    
-    # Stabilize it
-    stabedClip = repairedClip if stabilize == 0 else Stabilize(repairedClip, src, stabilize)
-    
-    
-    # Build AA Mask First then Merge it. Output depth is BPS
-          # ! Mask always being built under 8 bit ! #
-    if mclip is not None:
-        aaMask = mclip
+    def resize(self, clip, w, h, shift):
         try:
-            mergedClip = core.std.MaskedMerge(src, stabedClip, aaMask, planes=[0, 1, 2], first_plane=True)
-        except:
-            raise RuntimeError(FUNCNAME + ': Something wrong with your mclip. Check the resolution and bitdepth of mclip !')
-    else:
-        if mtype != 0:
-            if mtype == 1 or mtype == "Canny":
-                maskObj = mCanny(mthr, mthr2, mlthresh, mpand)
-                aaMask = maskObj.getMask(input8)
-            elif mtype == 2 or mtype == "CannySobel":
-                maskObj = mCannySobel(mthr, mthr2, mlthresh, mpand)
-                aaMask = maskObj.getMask(input8)
-            elif mtype == 3 or mtype == "Prewitt":
-                maskObj = mPrewitt(mthr, mlthresh, mpand)
-                aaMask = maskObj.getMask(input8)
-            else:
-                raise ValueError(FUNCNAME + ': Unknown mtype')
-            
-            # Let it back to 16 if input is 16bit
-            if BPS == 16:
-                aaMask = core.std.Expr(aaMask, "x 257 *", vs.GRAY16)
-                
-            mergedClip = core.std.MaskedMerge(src, stabedClip, aaMask, planes=[0, 1, 2], first_plane=True)
+            resized = self.core.resize.Spline36(clip, w, h, src_top=shift)
+        except vs.Error:
+            resized = self.core.fmtc.resample(clip, w, h, sy=shift)
+            if resized.format.bits_per_sample != self.process_depth:
+                mvf.Depth(resized, self.process_depth)
+        return resized
+
+    def down_8(self):
+        self.process_depth = 8
+        self.clip = mvf.Depth(self.clip, 8)
+
+
+class AANnedi3(AAParent):
+    def __init__(self, clip, strength=0, down8=False, **args):
+        super(AANnedi3, self).__init__(clip, strength, down8)
+        self.nsize = args.get('nsize', 3)
+        self.nns = args.get('nns', 1)
+        self.qual = args.get('qual', 2)
+
+    def out(self):
+        aaed = self.core.nnedi3.nnedi3(self.clip, field=1, dh=True, nsize=self.nsize, nns=self.nns, qual=self.qual)
+        aaed = self.resize(aaed, self.clip_width, self.clip_height, -0.5)
+        aaed = self.core.std.Transpose(aaed)
+        aaed = self.core.nnedi3.nnedi3(aaed, field=1, dh=True, nsize=self.nsize, nns=self.nns, qual=self.qual)
+        aaed = self.resize(aaed, self.clip_height, self.clip_width, -0.5)
+        aaed = self.core.std.Transpose(aaed)
+        return aaed
+
+
+class AANnedi3SangNom(AANnedi3):
+    def __init__(self, clip, strength=0, down8=False, **args):
+        super(AANnedi3SangNom, self).__init__(clip, strength, down8, **args)
+        self.aa = args.get('aa', 48)
+
+    def out(self):
+        aaed = self.core.nnedi3.nnedi3(self.clip, field=1, dh=True, nsize=self.nsize, nns=self.nns, qual=self.qual)
+        aaed = self.resize(aaed, self.clip_width, self.uph4, shift=-0.5)
+        aaed = self.core.std.Transpose(aaed)
+        aaed = self.core.nnedi3.nnedi3(aaed, field=1, dh=True, nsize=self.nsize, nns=self.nns, qual=self.qual)
+        aaed = self.resize(aaed, self.uph4, self.upw4, shift=-0.5)
+        aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+        aaed = self.core.std.Transpose(aaed)
+        aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+        aaed = self.resize(aaed, self.clip_width, self.clip_height, shift=0)
+        return aaed
+
+
+class AANnedi3UpscaleSangNom(AANnedi3SangNom):
+    def __init__(self, clip, strength=0, down8=False, **args):
+        super(AANnedi3UpscaleSangNom, self).__init__(clip, strength, down8, **args)
+        self.nsize = args.get('nsize', 1)
+        self.nns = args.get('nns', 3)
+        self.qual = args.get('qual', 2)
+
+
+class AAEedi3(AAParent):
+    def __init__(self, clip, strength=0, down8=False, **args):
+        super(AAEedi3, self).__init__(clip, strength, down8)
+        self.alpha = args.get('alpha', 0.5)
+        self.beta = args.get('beta', 0.2)
+        self.gamma = args.get('gamma', 20)
+        self.nrad = args.get('nrad', 3)
+        self.mdis = args.get('mdis', 30)
+        self.eedi3m = args.get('eedi3m', True)
+        # Make sure process depth is 8bit because eedi3 is too slow for high depth processing
+        if clip.format.bits_per_sample > 8:
+            self.clip = mvf.Depth(self.clip, 8)
+        try:
+            self.eedi3 = self.core.eedi3_092.eedi3
+        except AttributeError:
+            self.eedi3 = self.core.eedi3.eedi3
+            self.eedi3m = False
+
+    def build_eedi3_mask(self, clip):
+        eedi3_mask = self.core.nnedi3.nnedi3(clip, field=1, show_mask=True)
+        eedi3_mask = self.core.std.Expr([eedi3_mask, clip], "x 254 > x y - 0 = not and 255 0 ?")
+        eedi3_mask_turn = self.core.std.Transpose(eedi3_mask)
+        if self.dfactor != 1:
+            eedi3_mask_turn = self.core.resize.Bicubic(eedi3_mask_turn, self.clip_height, self.dw)
+        return eedi3_mask, eedi3_mask_turn
+
+    def out(self):
+        if self.eedi3m is False:
+            aaed = self.eedi3(self.clip, field=1, dh=True, alpha=self.alpha, beta=self.beta,
+                              gamma=self.gamma, nrad=self.nrad, mdis=self.mdis)
+            aaed = self.resize(aaed, self.dw, self.clip_height, shift=-0.5)
+            aaed = self.core.std.Transpose(aaed)
+            aaed = self.eedi3(aaed, field=1, dh=True, alpha=self.alpha, beta=self.beta,
+                              gamma=self.gamma, nrad=self.nrad, mdis=self.mdis)
+            aaed = self.resize(aaed, self.clip_height, self.clip_width, shift=-0.5)
+            aaed = self.core.std.Transpose(aaed)
+            aaed_bits = aaed.format.bits_per_sample
+            return aaed if aaed_bits == self.process_depth else mvf.Depth(aaed, self.process_depth)
+        elif self.eedi3m is True:
+            mask = self.build_eedi3_mask(self.clip)
+            aaed = self.eedi3(self.clip, field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma,
+                              nrad=self.nrad, mdis=self.mdis, mclip=mask[0])
+            aaed = self.resize(aaed, self.dw, self.clip_height, shift=-0.5)
+            aaed = self.core.std.Transpose(aaed)
+            aaed = self.eedi3(aaed, field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma,
+                              nrad=self.nrad, mdis=self.mdis, mclip=mask[1])
+            aaed = self.resize(aaed, self.clip_height, self.clip_width, shift=-0.5)
+            aaed = self.core.std.Transpose(aaed)
+            aaed_bits = aaed.format.bits_per_sample
+            return aaed if aaed_bits == self.process_depth else mvf.Depth(aaed, self.process_depth)
         else:
-            mergedClip = stabedClip
-    
-    # Build Text Mask if input is not GRAY
-    if IS_GRAY is False and txtprt is not None:
-        txtmObj = mText(txtprt)
-        txtMask = txtmObj.getMask(input8)
-        txtprtClip = core.std.MaskedMerge(mergedClip, src, txtMask, planes=[0, 1, 2], first_plane=True)
+            raise ValueError(MODULE_NAME + ': Incorrect eedi3m setting.')
+
+
+class AAEedi3SangNom(AAEedi3):
+    def __init__(self, clip, strength=0, down8=False, **args):
+        super(AAEedi3SangNom, self).__init__(clip, strength, down8, **args)
+        self.aa = args.get('aa', 48)
+
+    def build_eedi3_mask(self, clip):
+        eedi3_mask = self.core.nnedi3.nnedi3(clip, field=1, show_mask=True)
+        eedi3_mask = self.core.std.Expr([eedi3_mask, clip], "x 254 > x y - 0 = not and 255 0 ?")
+        eedi3_mask_turn = self.core.std.Transpose(eedi3_mask)
+        eedi3_mask_turn = self.core.resize.Bicubic(eedi3_mask_turn, self.uph4, self.dw)
+        return eedi3_mask, eedi3_mask_turn
+
+    def out(self):
+        if self.eedi3m is False:
+            aaed = self.eedi3(self.clip, field=1, dh=True, alpha=self.alpha, beta=self.beta,
+                              gamma=self.gamma, nrad=self.nrad, mdis=self.mdis)
+            aaed = self.resize(aaed, self.dw, self.uph4, shift=-0.5)
+            aaed = self.core.std.Transpose(aaed)
+            aaed = self.eedi3(aaed, field=1, dh=True, alpha=self.alpha, beta=self.beta,
+                              gamma=self.gamma, nrad=self.nrad, mdis=self.mdis)
+            aaed = self.resize(aaed, self.uph4, self.upw4, shift=-0.5)
+            aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+            aaed = self.core.std.Transpose(aaed)
+            aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+            aaed = self.resize(aaed, self.clip_width, self.clip_height, shift=0)
+            aaed_bits = aaed.format.bits_per_sample
+            return aaed if aaed_bits == self.process_depth else mvf.Depth(aaed, self.process_depth)
+        elif self.eedi3m is True:
+            mask = self.build_eedi3_mask(self.clip)
+            aaed = self.eedi3(self.clip, field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma,
+                              nrad=self.nrad, mdis=self.mdis, mclip=mask[0])
+            aaed = self.resize(aaed, self.dw, self.uph4, shift=-0.5)
+            aaed = self.core.std.Transpose(aaed)
+            aaed = self.eedi3(aaed, field=1, dh=True, alpha=self.alpha, beta=self.beta, gamma=self.gamma,
+                              nrad=self.nrad, mdis=self.mdis, mclip=mask[1])
+            aaed = self.resize(aaed, self.uph4, self.upw4, shift=-0.5)
+            aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+            aaed = self.core.std.Transpose(aaed)
+            aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+            aaed = self.resize(aaed, self.clip_width, self.clip_height, shift=0)
+            aaed_bits = aaed.format.bits_per_sample
+            return aaed if aaed_bits == self.process_depth else mvf.Depth(aaed, self.process_depth)
+        else:
+            raise ValueError(MODULE_NAME + ': Incorrect eedi3m setting.')
+
+
+class AAEedi2(AAParent):
+    def __init__(self, clip, strength=0, down8=False, **args):
+        super(AAEedi2, self).__init__(clip, strength, down8)
+        self.mthresh = args.get('mthresh', 10)
+        self.lthresh = args.get('lthresh', 20)
+        self.vthresh = args.get('vthresh', 20)
+        self.maxd = args.get('maxd', 24)
+        self.nt = args.get('nt', 50)
+
+    def out(self):
+        aaed = self.core.eedi2.EEDI2(self.clip, 1, self.mthresh, self.lthresh, self.vthresh, maxd=self.maxd, nt=self.nt)
+        aaed = self.resize(aaed, self.dw, self.clip_height, shift=-0.5)
+        aaed = self.core.std.Transpose(aaed)
+        aaed = self.core.eedi2.EEDI2(aaed, 1, self.mthresh, self.lthresh, self.vthresh, maxd=self.maxd, nt=self.nt)
+        aaed = self.resize(aaed, self.clip_height, self.clip_width, shift=-0.5)
+        aaed = self.core.std.Transpose(aaed)
+        return aaed
+
+
+class AAEedi2SangNom(AAEedi2):
+    def __init__(self, clip, strength=0, down8=False, **args):
+        super(AAEedi2SangNom, self).__init__(clip, strength, down8, **args)
+        self.aa = args.get('aa', 48)
+
+    def out(self):
+        aaed = self.core.eedi2.EEDI2(self.clip, 1, self.mthresh, self.lthresh, self.vthresh, maxd=self.maxd, nt=self.nt)
+        aaed = self.resize(aaed, self.dw, self.uph4, shift=-0.5)
+        aaed = self.core.std.Transpose(aaed)
+        aaed = self.core.eedi2.EEDI2(aaed, 1, self.mthresh, self.lthresh, self.vthresh, maxd=self.maxd, nt=self.nt)
+        aaed = self.resize(aaed, self.uph4, self.upw4, shift=-0.5)
+        aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+        aaed = self.core.std.Transpose(aaed)
+        aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+        aaed = self.resize(aaed, self.clip_width, self.clip_height, shift=0)
+        return aaed
+
+
+class AASpline64NRSangNom(AAParent):
+    def __init__(self, clip, strength=0, down8=False, **args):
+        super(AASpline64NRSangNom, self).__init__(clip, strength, down8)
+        self.aa = args.get('aa', 48)
+
+    def out(self):
+        aa_spline64 = self.core.fmtc.resample(self.clip, self.upw4, self.uph4, kernel='spline64')
+        aa_spline64 = mvf.Depth(aa_spline64, self.process_depth)
+        aa_gaussian = self.core.fmtc.resample(self.clip, self.upw4, self.uph4, kernel='gaussian', a1=100)
+        aa_gaussian = mvf.Depth(aa_gaussian, self.process_depth)
+        aaed = self.core.rgvs.Repair(aa_spline64, aa_gaussian, 1)
+        aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+        aaed = self.core.std.Transpose(aaed)
+        aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+        aaed = self.core.std.Transpose(aaed)
+        aaed = self.resize(aaed, self.clip_width, self.clip_height, shift=0)
+        return aaed
+
+
+class AASpline64SangNom(AAParent):
+    def __init__(self, clip, strength=0, down8=False, **args):
+        super(AASpline64SangNom, self).__init__(clip, strength, down8)
+        self.aa = args.get('aa', 48)
+
+    def out(self):
+        aaed = self.core.fmtc.resample(self.clip, self.clip_width, self.uph4, kernel="spline64")
+        aaed = mvf.Depth(aaed, self.process_depth)
+        aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+        aaed = self.core.std.Transpose(self.resize(aaed, self.clip_width, self.clip_height, 0))
+        aaed = self.core.fmtc.resample(aaed, self.clip_height, self.upw4, kernel="spline64")
+        aaed = mvf.Depth(aaed, self.process_depth)
+        aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+        aaed = self.core.std.Transpose(self.resize(aaed, self.clip_height, self.clip_width, 0))
+        return aaed
+
+
+class AAPointSangNom(AAParent):
+    def __init__(self, clip, down8=False, **args):
+        super(AAPointSangNom, self).__init__(clip, 0, down8)
+        self.aa = args.get('aa', 48)
+        self.upw = self.clip_width * 2
+        self.uph = self.clip_height * 2
+
+    def out(self):
+        aaed = self.core.resize.Point(self.clip, self.upw, self.uph)
+        aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+        aaed = self.core.std.Transpose(aaed)
+        aaed = self.core.sangnom.SangNom(aaed, aa=self.aa)
+        aaed = self.core.std.Transpose(aaed)
+        aaed = self.resize(aaed, self.clip_width, self.clip_height, 0)
+        return aaed
+
+
+class MaskParent(Clip):
+    def __init__(self, clip):
+        super(MaskParent, self).__init__(clip)
+        if clip.format.color_family is not vs.GRAY:
+            self.clip = self.core.std.ShufflePlanes(self.clip, 0, vs.GRAY)
+        self.clip = mvf.Depth(self.clip, 8)  # Mask will always be processed in 8bit scale
+        self.mask = None
+        self.multi = ((1 << self.clip_bits) - 1) // 255
+
+    def __add__(self, mask_b):
+        if not isinstance(mask_b, MaskParent):
+            raise TypeError(MODULE_NAME + ': Incorrect mask_b type.')
+        self.mask = self.core.std.Expr([self.mask, mask_b.mask], "x y max", vs.GRAY8)
+        return self
+
+    def expand(self, time):
+        for i in range(time):
+            self.mask = self.core.std.Maximum(self.mask)
+
+    def inpand(self, time):
+        for i in range(time):
+            self.mask = self.core.std.Minimum(self.mask)
+
+    def blur(self):
+        self.mask = self.core.rgvs.RemoveGrain(self.mask, 20)
+
+    def out(self):
+        out_type = eval('vs.GRAY{depth}'.format(depth=self.clip_bits))
+        return self.core.std.Expr(self.mask, 'x ' + str(self.multi) + ' *', out_type)
+
+
+class MaskCanny(MaskParent):
+    def __init__(self, clip, **kwargs):
+        super(MaskCanny, self).__init__(clip)
+        self.sigma = kwargs.get('sigma', 1.2)
+        self.t_h = kwargs.get('t_h', 8.0)
+        self.lthresh = kwargs.get('lthresh', None)
+        self.mpand = kwargs.get('mpand', [1, 0])
+
+        if isinstance(self.sigma, (list, tuple)) and isinstance(self.t_h, (list, tuple)) \
+                and isinstance(self.lthresh, (list, tuple)):
+            if len(self.sigma) != len(self.t_h) or len(self.lthresh) != len(self.sigma) - 1:
+                raise ValueError(MODULE_NAME + ': incorrect length of sigma, t_h or lthresh.')
+            self.mask = self.core.tcanny.TCanny(self.clip, sigma=self.sigma[0], t_h=self.t_h[0], mode=0, planes=0)
+            for i in range(len(self.lthresh)):
+                temp_mask = self.core.tcanny.TCanny(self.clip, sigma=self.sigma[i+1], t_h=self.t_h[i+1],
+                                                    mode=0, planes=0)
+                expr = "x " + str(self.lthresh[i]) + " < z y ?"
+                self.mask = self.core.std.Expr([self.clip, temp_mask, self.mask], expr)
+        elif not isinstance(self.sigma, (list, tuple)) and not isinstance(self.t_h, (list, tuple)):
+            self.mask = self.core.tcanny.TCanny(self.clip, sigma=self.sigma, t_h=self.t_h, mode=0, planes=0)
+        else:
+            raise ValueError(MODULE_NAME + ': sigma, t_h, lthresh shoule be same type (num, list or tuple).')
+
+        if not isinstance(self.mpand, (list, tuple)):
+            self.mpand = [self.mpand, self.mpand]
+        if self.mpand != [0, 0] and self.mpand != (0, 0):
+            self.expand(self.mpand[0])
+            self.inpand(self.mpand[1])
+
+
+class MaskSobel(MaskParent):
+    def __init__(self, clip, **kwargs):
+        super(MaskSobel, self).__init__(clip)
+        self.binarize = kwargs.get('binarize', 48)
+        self.sigma = kwargs.get('sigma', 1.2)
+        self.lthresh = kwargs.get('lthresh', None)
+        self.mpand = kwargs.get('mpand', [1, 1])
+
+        eemask = self.core.tcanny.TCanny(self.clip, sigma=self.sigma, mode=1, op=2, planes=0)
+        if isinstance(self.binarize, (list, tuple)) and isinstance(self.lthresh, (list, tuple)):
+            if len(self.lthresh) != len(self.binarize) - 1:
+                raise ValueError(MODULE_NAME + ': incorrect length of sigma, binarize or lthresh.')
+            expr = 'x {binarize} < 0 255 ?'.format(binarize=self.binarize[0])
+            self.mask = self.core.std.Expr(eemask, expr)
+            for i in range(len(self.lthresh)):
+                temp_expr = 'x {binarize} < 0 255 ?'.format(binarize=self.binarize[i+1])
+                temp_mask = self.core.std.Expr(eemask, temp_expr)
+                luma_expr = 'x {thresh} < z y ?'.format(thresh=self.lthresh[i])
+                self.mask = self.core.std.Expr([self.clip, temp_mask, self.mask], luma_expr)
+        elif not isinstance(self.binarize, (list, tuple)):
+            expr = 'x {binarize} < 0 255 ?'.format(binarize=self.binarize)
+            self.mask = self.core.std.Expr(eemask, expr)
+        else:
+            raise ValueError(MODULE_NAME + ': binarzie and lthresh should be same type (num, list, tuple).')
+
+        if not isinstance(self.mpand, (list, tuple)):
+            self.mpand = [self.mpand, self.mpand]
+        if self.mpand != [0, 0] and self.mpand != (0, 0):
+            self.expand(self.mpand[0])
+            self.inpand(self.mpand[1])
+
+
+class MaskPrewitt(MaskParent):
+    def __init__(self, clip, **kwargs):
+        super(MaskPrewitt, self).__init__(clip)
+        self.factor = kwargs.get('factor', 62)
+        self.lthresh = kwargs.get('lthresh', None)
+        self.mpand = kwargs.get('mpand', 0)
+
+        eemask_1 = self.core.std.Convolution(self.clip, [1, 1, 0, 1, 0, -1, 0, -1, -1], divisor=1, saturate=False)
+        eemask_2 = self.core.std.Convolution(self.clip, [1, 1, 1, 0, 0, 0, -1, -1, -1], divisor=1, saturate=False)
+        eemask_3 = self.core.std.Convolution(self.clip, [1, 0, -1, 1, 0, -1, 1, 0, -1], divisor=1, saturate=False)
+        eemask_4 = self.core.std.Convolution(self.clip, [0, -1, -1, 1, 0, -1, 1, 1, 0], divisor=1, saturate=False)
+        eemask = self.core.std.Expr([eemask_1, eemask_2, eemask_3, eemask_4], "x y max z max a max")
+        if isinstance(self.factor, (list, tuple)) and isinstance(self.lthresh, (list, tuple)):
+            if len(self.lthresh) != len(self.factor) - 1:
+                raise ValueError(MODULE_NAME + ': incorrect length of lthresh or factor.')
+            expr = 'x {factor} <= x 2 / x 1.4 pow ?'.format(factor=self.factor[0])
+            self.mask = self.core.std.Expr(eemask, expr)
+            for i in range(len(self.lthresh)):
+                temp_expr = "x {factor} <= x 2 / x 1.4 pow ?".format(factor=self.factor[i+1])
+                temp_mask = self.core.std.Expr(eemask, temp_expr)
+                luma_expr = "x {lthresh} < z y ?".format(lthresh=self.lthresh[i])
+                self.mask = self.core.std.Expr([self.clip, temp_mask, self.mask], luma_expr)
+        elif not isinstance(self.factor, (list, tuple)):
+            expr = "x {factor} <= x 2 / x 1.4 pow ?".format(factor=self.factor)
+            self.mask = self.core.std.Expr(eemask, expr)
+        else:
+            raise ValueError(MODULE_NAME + ': factor and lthresh should be same type (num, list or tuple).')
+
+        if not isinstance(self.mpand, (list, tuple)):
+            self.mpand = [self.mpand, self.mpand]
+        if self.mpand != [0, 0] and self.mpand != (0, 0):
+            self.expand(self.mpand[0])
+            self.inpand(self.mpand[1])
+
+
+class FadeTextMask(MaskParent):
+    def __init__(self, clip, **kwargs):
+        super(FadeTextMask, self).__init__(clip)
+        self.clip = mvf.Depth(clip, 8)
+        self.lthr = kwargs.get('lthr', 225)
+        self.cthr = kwargs.get('cthr', 2)
+        self.mexpand = kwargs.get('expand', 2)
+        self.fade_nums = kwargs.get('fade_num', 8)
+        self.apply_range = kwargs.get('apply_range', None)
+
+        if self.clip_color_family is not vs.YUV:
+            raise TypeError(MODULE_NAME + ': clip should be a YUV clip')
+
+        y = self.core.std.ShufflePlanes(self.clip, 0, vs.GRAY)
+        u = self.core.std.ShufflePlanes(self.clip, 1, vs.GRAY)
+        v = self.core.std.ShufflePlanes(self.clip, 2, vs.GRAY)
+        try:
+            u = self.core.resize.Bicubic(u, self.clip_width, self.clip_height, src_left=0.25)
+            v = self.core.resize.Bicubic(v, self.clip_width, self.clip_height, src_left=0.25)
+        except vs.Error:
+            u = mvf.Depth(self.core.fmtc.resample(u, self.clip_width, self.clip_height, sx=0.25), 8)
+            v = mvf.Depth(self.core.fmtc.resample(v, self.clip_width, self.clip_height, sx=0.25), 8)
+
+        expr = "x {lthr} > y 128 - abs {cthr} < and z 128 - abs {cthr} < and 255 0 ?".format(lthr=self.lthr,
+                                                                                             cthr=self.cthr)
+        self.mask = self.core.std.Expr([y, u, v], expr)
+        if self.mexpand > 0:
+            self.expand(self.mexpand)
+
+        frame_count = self.clip.num_frames
+
+        def shift_backward(n, clip, num):
+            if n + num > frame_count - 1:
+                return clip[frame_count - 1]
+            else:
+                return clip[n + num]
+
+        def shift_forward(n, clip, num):
+            if n - num < 0:
+                return clip[0]
+            else:
+                return clip[n - num]
+
+        if isinstance(self.fade_nums, int):
+            in_num = self.fade_nums
+            out_num = self.fade_nums
+        elif isinstance(self.fade_nums, (list, tuple)):
+            if len(self.fade_nums) != 2:
+                raise ValueError(MODULE_NAME + ': incorrect fade_nums setting.')
+            in_num = self.fade_nums[0]
+            out_num = self.fade_nums[1]
+        else:
+            raise TypeError(MODULE_NAME + ': fade_num can only be int, tuple or list.')
+
+        if self.fade_nums is not 0:
+            fade_in = self.core.std.FrameEval(self.mask, functools.partial(shift_backward, clip=self.mask, num=in_num))
+            fade_out = self.core.std.FrameEval(self.mask, functools.partial(shift_forward, clip=self.mask, num=out_num))
+            self.mask = self.core.std.Expr([self.mask, fade_in, fade_out], " x y max z max")
+
+        if self.apply_range is not None:
+            if not isinstance(self.apply_range, (list, tuple)):
+                raise TypeError(MODULE_NAME + ': apply range can only be list or tuple.')
+            elif len(self.apply_range) != 2:
+                raise ValueError(MODULE_NAME + ': incorrect apply range setting.')
+            else:
+                try:
+                    blank_clip = self.core.std.BlankClip(self.mask)
+                    if 0 in self.apply_range:
+                        self.mask = self.mask[self.apply_range[0]:self.apply_range[1]] + \
+                                    blank_clip[self.apply_range[1]:]
+                    elif frame_count in self.apply_range:
+                        self.mask = blank_clip[0:self.apply_range[0]] + \
+                                    self.mask[self.apply_range[0]:self.apply_range[1]]
+                    else:
+                        self.mask = blank_clip[0:self.apply_range[0]] + \
+                                    self.mask[self.apply_range[0]:self.apply_range[1]] + \
+                                    blank_clip[self.apply_range[1]:]
+                except vs.Error:
+                    raise ValueError(MODULE_NAME + ': incorrect apply range setting. Possible end less than start.')
+
+
+def daa(clip, mode=-1):
+    core = vs.get_core()
+    if mode == -1:
+        nn = core.nnedi3.nnedi3(clip, field=3)
+        nnt = core.nnedi3.nnedi3(core.std.Transpose(clip), field=3).std.Transpose()
+        clph = core.std.Merge(core.std.SelectEvery(nn, cycle=2, offsets=0),
+                              core.std.SelectEvery(nn, cycle=2, offsets=1))
+        clpv = core.std.Merge(core.std.SelectEvery(nnt, cycle=2, offsets=0),
+                              core.std.SelectEvery(nnt, cycle=2, offsets=1))
+        clp = core.std.Merge(clph, clpv)
+    elif mode == 1:
+        nn = core.nnedi3.nnedi3(clip, field=3)
+        clp = core.std.Merge(core.std.SelectEvery(nn, cycle=2, offsets=0),
+                             core.std.SelectEvery(nn, cycle=2, offsets=1))
+    elif mode == 2:
+        nnt = core.nnedi3.nnedi3(core.std.Transpose(clip), field=3).std.Transpose()
+        clp = core.std.Merge(core.std.SelectEvery(nnt, cycle=2, offsets=0),
+                             core.std.SelectEvery(nnt, cycle=2, offsets=1))
     else:
-        txtprtClip = mergedClip
-    
-    
-    # Clamp loss if input is 16bit and down8 is set
-    if BPS == 16 and down8 is True:
-        outClip = mvf.LimitFilter(src, txtprtClip, thr=1.0, elast=2.0)
+        raise ValueError(MODULE_NAME + ': daa: at least one direction should be processed.')
+    return clp
+
+
+def temporal_stabilize(clip, src, delta=3, pel=1, retain=0.6):
+    core = vs.get_core()
+    clip_bits = clip.format.bits_per_sample
+    src_bits = src.format.bits_per_sample
+    if clip_bits != src_bits:
+        raise ValueError(MODULE_NAME + ': temporal_stabilize: bits depth of clip and src mismatch.')
+
+    diff = core.std.MakeDiff(src, clip)
+    clip_super = core.mv.Super(clip, pel=pel)
+    diff_super = core.mv.Super(diff, pel=pel, levels=1)
+
+    fv3 = core.mv.Analyse(clip_super, isb=False, delta=3, overlap=8, blksize=16) if delta == 3 else None
+    fv2 = core.mv.Analyse(clip_super, isb=False, delta=2, overlap=8, blksize=16) if delta >= 2 else None
+    fv1 = core.mv.Analyse(clip_super, isb=False, delta=1, overlap=8, blksize=16) if delta >= 1 else None
+    bv1 = core.mv.Analyse(clip_super, isb=True, delta=1, overlap=8, blksize=16) if delta >= 1 else None
+    bv2 = core.mv.Analyse(clip_super, isb=True, delta=2, overlap=8, blksize=16) if delta >= 2 else None
+    bv3 = core.mv.Analyse(clip_super, isb=True, delta=3, overlap=8, blksize=16) if delta == 3 else None
+
+    if delta == 1:
+        diff_stabilized = core.mv.Degrain1(diff, diff_super, bv1, fv1)
+    elif delta == 2:
+        diff_stabilized = core.mv.Degrain2(diff, diff_super, bv1, fv1, bv2, fv2)
+    elif delta == 3:
+        diff_stabilized = core.mv.Degrain3(diff, diff_super, bv1, fv1, bv2, fv2, bv3, fv3)
     else:
-        outClip = txtprtClip
-        
-    # Showmask or output
+        raise ValueError(MODULE_NAME + ': temporal_stabilize: delta (1~3) invalid.')
+
+    neutral = 1 << (clip_bits - 1)
+    expr = 'x {neutral} - abs y {neutral} - abs < x y ?'.format(neutral=neutral)
+    diff_stabilized_limited = core.std.Expr([diff, diff_stabilized], expr)
+    diff_stabilized = core.std.Merge(diff_stabilized_limited, diff_stabilized, retain)
+    clip_stabilized = core.std.MakeDiff(src, diff_stabilized)
+    return clip_stabilized
+
+
+def soothe(clip, src, keep=24):
+    core = vs.get_core()
+    clip_bits = clip.format.bits_per_sample
+    src_bits = src.format.bits_per_sample
+    if clip_bits != src_bits:
+        raise ValueError(MODULE_NAME + ': temporal_stabilize: bits depth of clip and src mismatch.')
+
+    neutral = 1 << (clip_bits - 1)
+    ceil = (1 << clip_bits) - 1
+    multiple = ceil // 255
+    const = 100 * multiple
+    kp = keep * multiple
+
+    diff = core.std.MakeDiff(src, clip)
+    try:
+        diff_soften = core.misc.AverageFrame(diff, weights=[1, 1, 1], scenechange=32)
+    except AttributeError:
+        diff_soften = core.focus.TemporalSoften(diff, radius=1, luma_threshold=255,
+                                                chroma_threshold=255, scenechange=32, mode=2)
+    diff_soothed_expr = "x {neutral} - y {neutral} - * 0 < x {neutral} - {const} / {kp} * {neutral} + " \
+                        "x {neutral} - abs y {neutral} - abs > " \
+                        "x {kp} * y {const} {kp} - * + {const} / x ? ?".format(neutral=neutral, const=const, kp=kp)
+    diff_soothed = core.std.Expr([diff, diff_soften], diff_soothed_expr)
+    clip_soothed = core.std.MakeDiff(src, diff_soothed)
+    return clip_soothed
+
+
+def TAAmbk(clip, aatype=1, aatypeu=None, aatypev=None, preaa=0, strength=0.0, cycle=0, mtype=None, mclip=None,
+           mthr=None, mthr2=None, mlthresh=None, mpand=(1, 0), txtmask=0, txtfade=0, thin=0, dark=0.0, sharp=0,
+           aarepair=0, postaa=None, src=None, stabilize=0, down8=True, showmask=0, eedi3m=True, **pn):
+    core = vs.get_core()
+    aatypeu = aatype if aatypeu is None else aatypeu
+    aatypev = aatype if aatypev is None else aatypev
+
+    if mtype is None:
+        mtype = 0 if preaa == 0 and True not in (aatype, aatypeu, aatypev) else 1
+
+    if postaa is None:
+        postaa = True if abs(sharp) > 70 or (0.4 < abs(sharp) < 1) else False
+
+    if src is None:
+        src = clip
+    else:
+        if clip.format.id is not src.format.id:
+            raise ValueError(MODULE_NAME + ': clip format and src format mismatch.')
+        elif clip.width != src.width or clip.height != src.height:
+            raise ValueError(MODULE_NAME + ': clip resolution and src resolution mismatch.')
+
+    preaa_clip = clip if preaa == 0 else daa(clip, preaa)
+
+    if thin == 0 and dark == 0:
+        edge_enhanced_clip = preaa_clip
+    elif thin != 0 and dark != 0:
+        edge_enhanced_clip = haf.Toon(core.warp.AWarpSharp2(preaa_clip, depth=int(thin)), str=float(dark))
+    elif thin == 0:
+        edge_enhanced_clip = haf.Toon(preaa_clip, str=float(dark))
+    else:
+        edge_enhanced_clip = core.warp.AWarpSharp2(preaa_clip, depth=int(thin))
+
+    aa_kernel = {
+        1: AAEedi2,
+        2: AAEedi3,
+        3: AANnedi3,
+        4: AANnedi3UpscaleSangNom,
+        5: AASpline64NRSangNom,
+        6: AASpline64SangNom,
+        -1: AAEedi2SangNom,
+        -2: AAEedi3SangNom,
+        -3: AANnedi3SangNom,
+        'Eedi2': AAEedi2,
+        'Eedi3': AAEedi3,
+        'Nnedi3': AANnedi3,
+        'Nnedi3UpscaleSangNom': AANnedi3UpscaleSangNom,
+        'Spline64NrSangNom': AASpline64NRSangNom,
+        'Spline64SangNom': AASpline64SangNom,
+        'Eedi2SangNom': AAEedi2SangNom,
+        'Eedi3SangNom': AAEedi3SangNom,
+        'Nnedi3SangNom': AANnedi3SangNom,
+        'PointSangNom': AAPointSangNom
+    }
+
+    aaed_clip = None
+    if clip.format.color_family is vs.YUV:
+        y = core.std.ShufflePlanes(edge_enhanced_clip, 0, vs.GRAY)
+        u = core.std.ShufflePlanes(edge_enhanced_clip, 1, vs.GRAY)
+        v = core.std.ShufflePlanes(edge_enhanced_clip, 2, vs.GRAY)
+        if aatype != 0:
+            try:
+                y = aa_kernel[aatype](y, strength, down8, eedi3m=eedi3m, **pn).out()
+                cycle_y = cycle
+                while cycle_y > 0:
+                    y = aa_kernel[aatype](y, strength, down8, eedi3m=eedi3m, **pn).out()
+                    cycle_y -= 1
+                y = mvf.Depth(y, clip.format.bits_per_sample) if down8 is True else y
+            except KeyError:
+                raise ValueError(MODULE_NAME + ': unknown aatype.')
+        if aatypeu != 0:
+            try:
+                u = aa_kernel[aatypeu](u, 0, down8, eedi3m=eedi3m, **pn).out()  # Won't do predown for u plane
+                cycle_u = cycle
+                while cycle_u > 0:
+                    u = aa_kernel[aatypeu](u, 0, down8, eedi3m=eedi3m, **pn).out()
+                    cycle_u -= 1
+                u = mvf.Depth(u, clip.format.bits_per_sample) if down8 is True else u
+            except KeyError:
+                raise ValueError(MODULE_NAME + ': unknown aatypeu.')
+        if aatypev != 0:
+            try:
+                v = aa_kernel[aatypev](v, 0, down8, eedi3m=eedi3m, **pn).out()  # Won't do predown for v plane
+                cycle_v = cycle
+                while cycle_v > 0:
+                    v = aa_kernel[aatypev](v, 0, down8, eedi3m=eedi3m, **pn).out()
+                    cycle_v -= 1
+                v = mvf.Depth(v, clip.format.bits_per_sample) if down8 is True else v
+            except KeyError:
+                raise ValueError(MODULE_NAME + ': unknown aatypev.')
+        aaed_clip = core.std.ShufflePlanes([y, u, v], [0, 0, 0], vs.YUV)
+    elif clip.format.color_family is vs.GRAY:
+        y = edge_enhanced_clip
+        if aatype != 0:
+            try:
+                y = aa_kernel[aatype](y, strength, down8, **pn).out()
+                cycle_y = cycle
+                while cycle_y > 0:
+                    y = aa_kernel[aatype](y, strength, down8, **pn).out()
+                    cycle_y -= 1
+                aaed_clip = mvf.Depth(y, clip.format.bits_per_sample) if down8 is True else y
+            except KeyError:
+                raise ValueError(MODULE_NAME + ': unknown aatype.')
+    else:
+        raise ValueError(MODULE_NAME + ': Unsupported color family.')
+
+    abs_sharp = abs(sharp)
+    if sharp >= 1:
+        sharped_clip = haf.LSFmod(aaed_clip, strength=int(abs_sharp), defaults='old', source=src)
+    elif sharp > 0:
+        per = int(40 * abs_sharp)
+        matrix = [-1, -2, -1, -2, 52 - per, -2, -1, -2, -1]
+        sharped_clip = core.std.Convolution(aaed_clip, matrix)
+    elif sharp > -1:
+        sharped_clip = haf.LSFmod(aaed_clip, strength=round(abs_sharp * 100), defaults='fast', source=src)
+    elif sharp == -1:
+        blured = core.rgvs.RemoveGrain(aaed_clip, mode=20 if aaed_clip.width > 1100 else 11)
+        diff = core.std.MakeDiff(aaed_clip, blured)
+        diff = core.std.Repair(diff, core.std.MakeDiff(src, aaed_clip), mode=13)
+        sharped_clip = core.std.MergeDiff(aaed_clip, diff)
+    else:
+        sharped_clip = aaed_clip
+
+    postaa_clip = sharped_clip if postaa is False else soothe(sharped_clip, src, 24)
+    repaired_clip = postaa_clip if aarepair == 0 else core.rgvs.Repair(src, postaa_clip, aarepair)
+    stabilized_clip = repaired_clip if stabilize == 0 else temporal_stabilize(repaired_clip, src, stabilize)
+
+    if mclip is not None:
+        mask = mclip
+        try:
+            masked_clip = core.std.MaskedMerge(src, stabilized_clip, mask, first_plane=True)
+        except vs.Error:
+            raise RuntimeError(MODULE_NAME + ': Something wrong with your mclip. '
+                                             'Maybe resolution or bit_depth mismatch.')
+    elif mtype != 0:
+        if mtype == 1 or mtype is 'Canny':
+            mthr = 1.2 if mthr is None else mthr
+            mthr2 = 8.0 if mthr2 is None else mthr2
+            mask = MaskCanny(clip, sigma=mthr, t_h=mthr2, lthresh=mlthresh, mpand=mpand).out()
+        elif mtype == 2 or mtype is 'Sobel':
+            mthr = 1.2 if mthr is None else mthr
+            mthr2 = 48 if mthr2 is None else mthr2
+            mask = MaskSobel(clip, sigma=mthr, binarize=mthr2, lthresh=mlthresh, mpand=mpand).out()
+        elif mtype == 3 or mtype is 'prewitt':
+            mthr = 62 if mthr is None else mthr
+            mask = MaskPrewitt(clip, factor=mthr, lthresh=mlthresh, mpand=mpand).out()
+        else:
+            raise ValueError(MODULE_NAME + ': unknown mtype.')
+        masked_clip = core.std.MaskedMerge(src, stabilized_clip, mask)
+    else:
+        masked_clip = stabilized_clip
+
+    if txtmask > 0 and clip.format.color_family is not vs.GRAY:
+        text_mask = FadeTextMask(clip, lthr=txtmask, fade_nums=txtfade).out()
+        txt_protected_clip = core.std.MaskedMerge(masked_clip, src, text_mask, first_plane=True)
+    else:
+        txt_protected_clip = masked_clip
+
+    if clip.format.bits_per_sample > 8 and down8 is True:
+        clamped_clip = mvf.LimitFilter(src, txt_protected_clip, thr=1.0, elast=2.0)
+    else:
+        clamped_clip = txt_protected_clip
+
     if showmask == -1:
         try:
-            return txtMask
+            return text_mask
         except UnboundLocalError:
-            raise RuntimeError(FUNCNAME + ': No txtmask to show if you don\'t have one.')
-            
+            raise RuntimeError(MODULE_NAME + ': No txtmask to show if you don\'t have one.')
     elif showmask == 1:
         try:
-            return aaMask
+            return mask
         except UnboundLocalError:
-            raise RuntimeError(FUNCNAME + ': No mask to show if you don\'t have one.')
+            raise RuntimeError(MODULE_NAME + ': No mask to show if you don\'t have one.')
     elif showmask == 2:
         try:
-            return core.std.StackVertical([core.std.ShufflePlanes([aaMask, core.std.BlankClip(src)], [0, 1, 2], vs.YUV), src])
+            return core.std.StackVertical(
+                [core.std.ShufflePlanes([mask, core.std.BlankClip(src)], [0, 1, 2], vs.YUV), src])
         except UnboundLocalError:
-            raise RuntimeError(FUNCNAME + ': No mask to show if you don\'t have one.')
+            raise RuntimeError(MODULE_NAME + ': No mask to show if you don\'t have one.')
     elif showmask == 3:
         try:
-            return core.std.Interleave([core.std.ShufflePlanes([aaMask, core.std.BlankClip(src)], [0, 1, 2], vs.YUV), src])
+            return core.std.Interleave(
+                [core.std.ShufflePlanes([mask, core.std.BlankClip(src)], [0, 1, 2], vs.YUV), src])
         except UnboundLocalError:
-            raise RuntimeError(FUNCNAME + ': No mask to show if you don\'t have one.')
+            raise RuntimeError(MODULE_NAME + ': No mask to show if you don\'t have one.')
     else:
-        return outClip
+        return clamped_clip


### PR DESCRIPTION
VS版本：R38，滤镜：最新版

脚本：
import vapoursynth as vs
import mvsfunc as mvf
import havsfunc as haf
import vsTAAmbk as taa
import CSMOD as cs
import nnedi3_resample as nnrs
import adjust

core = vs.get_core(accept_lowercase=True)
core.max_cache_size = 10240

src8=core.lsmas.LWLibavSource(r"D:\[AIKATSU_STARS][01]\BDMV\STREAM\00006.m2ts",threads=1)
src16=mvf.Depth(src8,depth=16)

taa=taa.TAAmbk(src16,preaa=0, sharp=-1, postaa=False, mtype=2)

output=core.fmtc.bitdepth(taa,bits=16)
output.set_output()


报错：
Python exception: There is no function named Repair

Traceback (most recent call last):
File "src\cython\vapoursynth.pyx", line 1810, in vapoursynth.vpy_evaluateScript (src\cython\vapoursynth.c:36455)
File "D:/[AIKATSU_STARS][01]/BDMV/STREAM/00006.vpy", line 15, in 
taa=taa.TAAmbk(src16,preaa=0, sharp=-1, postaa=False, mtype=2)
File "C:\Program Files\Python36\lib\site-packages\vsTAAmbk.py", line 706, in TAAmbk
diff = core.std.Repair(diff, core.std.MakeDiff(src, aaed_clip), mode=13)
File "src\cython\vapoursynth.pyx", line 1570, in vapoursynth.Plugin.__getattr__ (src\cython\vapoursynth.c:32428)
AttributeError: There is no function named Repair
该如何解决